### PR TITLE
Please accept those modifications 

### DIFF
--- a/lib/CWMP/Session.pm
+++ b/lib/CWMP/Session.pm
@@ -132,7 +132,8 @@ sub process_request {
 		$job->finish;
 	} else {
 		my @dispatch;
-		@dispatch = CWMP::Vendor->all_parameters( $self->store, $uid, $queue );
+		# @dispatch = CWMP::Vendor->all_parameters( $self->store, $uid, $queue );
+		@dispatch = CWMP::Vendor->some_parameters( $self->store, $uid, $queue );
 warn "XXX", dump @dispatch;
 		@dispatch = CWMP::Vendor->vendor_config( $self->store, $uid, $queue ) unless @dispatch;
 warn "XXX", dump @dispatch;


### PR DESCRIPTION
I have made 3 modifications to the code to improve it. They work well for my use and I am sure they will be useful to others as well.

The first modification is that I updated (according to the current standard) the SOAP header. Because it was incorrectly set many TR069 devices I have tested (and basically all that worked with the Broadcom TR069 client) was rejecting the request.

The second modification is that all the properties now may have type. Before it was unspecified. The current broadband forum standard requests this strictly and many devices do not accept SetParameter requests from this ACS server.

Because this ACS server does not know the XSD, you have to set it specifically if you need to. This is an example how to do it (unsigned int of 60). If you dont specify it, it keeps the previous default behavior:
InternetGatewayDevice.ManagementServer.PeriodicInformInterval: #xsd:unsignedInt#60

The third modification allows the insertion of a value of previously read variable.
You can use that value by ${}. Here is an example to set a password to the value of the Serial Number:
InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANPPPConnection.1.Password: ${InternetGatewayDevice.DeviceInfo.SerialNumber}

Also we can execute external code and evaluate the output. This is an example:
InternetGatewayDevice.DeviceInfo.ProvisioningCode: $[ `./blabla.pl ${InternetGatewayDevice.LANDevice.1.LANEthernetInterfaceConfig.1.MACAddress} ${InternetGatewayDevice.DeviceInfo.SerialNumber}`; "configured" ]

All this is very valuable for dynamic and automated configurations without the need of modification of the core code, just modifying the configuration file.
